### PR TITLE
Update to work with latest Commandhelper (GlobalEnv -> StaticRuntimeEnv)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # THIS EXTENSION IS HIGHLY EXPERIMENTAL! #
 
-**!!!! Latest versions require CommandHelper 3.3.4 build #3603 or later !!!!**
+**!!!! Latest versions require CommandHelper 3.3.4 build #3978 or later !!!!**
 
 While some small amount of testing has been done to verify that SOMETHING works,
 we do not take any responsibility for any damages caused by the use of this

--- a/src/main/java/com/laytonsmith/extensions/chsc/Functions.java
+++ b/src/main/java/com/laytonsmith/extensions/chsc/Functions.java
@@ -18,7 +18,7 @@ import com.laytonsmith.core.constructs.CNull;
 import com.laytonsmith.core.constructs.CString;
 import com.laytonsmith.core.constructs.Target;
 import com.laytonsmith.core.environments.Environment;
-import com.laytonsmith.core.environments.GlobalEnv;
+import com.laytonsmith.core.environments.StaticRuntimeEnv;
 import com.laytonsmith.core.exceptions.CRE.CREFormatException;
 import com.laytonsmith.core.exceptions.CRE.CREIOException;
 import com.laytonsmith.core.exceptions.CRE.CREInsufficientArgumentsException;
@@ -73,7 +73,7 @@ public class Functions {
             }
             
             NodePoint node;
-            DaemonManager daemon = environment.getEnv(GlobalEnv.class).GetDaemonManager();
+            DaemonManager daemon = environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager();
             
             try {
                 node = Tracking.getOrCreate(daemon, type, name);
@@ -120,7 +120,7 @@ public class Functions {
             }
             
             NodePoint node;
-            DaemonManager daemon = environment.getEnv(GlobalEnv.class).GetDaemonManager();
+            DaemonManager daemon = environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager();
             
             try {
                 node = Tracking.getOrCreate(daemon, type, name);
@@ -176,7 +176,7 @@ public class Functions {
             }
             
             NodePoint node;
-            DaemonManager daemon = environment.getEnv(GlobalEnv.class).GetDaemonManager();
+            DaemonManager daemon = environment.getEnv(StaticRuntimeEnv.class).GetDaemonManager();
             
             try {
                 node = Tracking.getOrCreate(daemon, type, name);


### PR DESCRIPTION
CommandHelper moved `GetDaemonManager()` from `GlobalEnv` to `StaticRuntimeEnv` in EngineHub/CommandHelper@675fab075c675bf7f4cd6257972501c7a64e3540  
This change would break backward compatibility for older CH versions (build 3977 or older).